### PR TITLE
Feauture: turbo-speed state for a selection of higher speeds

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -38,6 +38,7 @@ class Configuration {
     kCycleAngle = 'a',
     kCycleSpeed = 's',
     kToggleMotion = 'm',
+    kToggleTurbo = 't',
     kToggleLogReport = 'r',
     kLogGeneralStatus = 'l',
     kReportFirmwareVersion = 'v',
@@ -98,8 +99,12 @@ class Configuration {
   const float kSweepAngles_degrees_[kSizeOfSweepAngles_] = {45.0F, 90.0F, 180.0F, 360.0F}; ///< Lookup table for sweep angles (degrees) during oscillation.
   const uint8_t kDefaultSweepAngleIndex_ = 0; ///< Index of initial/default sweep angle.
   static constexpr uint8_t kSizeOfSpeeds_ = 4; ///< No. of speeds in the lookup table.
-  const float kSpeeds_RPM_[kSizeOfSpeeds_] = {7.0F, 10.0F, 13.0F, 16.0F}; ///< Lookup table for rotation speeds (RPM).
-  const uint8_t kDefaultSpeedIndex_ = 0; ///< Index of initial/default speed.
+  /// @brief Lookup table for rotation speeds (RPM).
+  const float kSpeeds_RPM_[2][kSizeOfSpeeds_] = {{7.0F,  10.5F, 14.0F, 21.0F},  // Row 0: Normal speeds: S, 1.5S, 2S, 3S.
+                                                 {35.0F, 42.0F, 56.0F, 77.0F}}; // Row 1: Turbo speeds: 5S, 6S, 8S, 11S.
+  //                                        Index: 0       1      2      3
+  const uint8_t kDefaultSpeedRow_ = 0; // Row of initial/default speed state.
+  const uint8_t kDefaultSpeedIndex_ = 0; // Index of initial/default speed.
   const float kAcceleration_microsteps_per_s_per_s_ = 6000.0; //8000.0; ///< Acceleration (microsteps per second-squared).
   const mt::StepperDriver::AccelerationAlgorithm kAccelerationAlgorithm_ = mt::StepperDriver::AccelerationAlgorithm::kMorgridge24; ///< Acceleration algorithm.
 

--- a/src/control_system.h
+++ b/src/control_system.h
@@ -73,6 +73,7 @@ class ControlSystem {
   float sweep_direction_ = static_cast<float>(motion_direction_); ///< Variable to keep track of the sweep direction.
   uint8_t sweep_angle_index_ = configuration_.kDefaultSweepAngleIndex_; ///< Index to keep track of the sweep angle set from the lookup table.
   uint8_t speed_index_ = configuration_.kDefaultSpeedIndex_; ///< Index to keep track of the motor speed set from the lookup table.
+  uint8_t speed_row_ = configuration_.kDefaultSpeedRow_; ///< Row to keep track of the motor speed state set from the lookup table.
   mt::StepperDriver::MotionStatus motion_status_ = mt::StepperDriver::MotionStatus::kIdle; ///< Variable to keep track of the motion status.
 };
 


### PR DESCRIPTION
Added "turbo-speed" state: 
- Selectable via a long press of the speed button (repeated to switch back to normal-speed state).
- Updated normal speeds (RPM): 7, 10.5, 14, 21
- New turbo-speeds (RPM): 35, 42, 56, 77